### PR TITLE
feat: add $WORKDIR to control where scripts get run

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -28,9 +28,8 @@ on:
         required: true
 
       WORKDIR:
-        description: "source directory to preform scripts"
+        description: "(optional)source directory to perform scripts, default to empty string"
         default: ''
-        required: false
 
 jobs:
   Generator:
@@ -59,6 +58,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git tag --delete ${P} || echo yes
 
+      - name: update go version
+        if: inputs.LANG == 'golang'
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.21.0'
 
       - name: Generate golang deps
         if: inputs.LANG == 'golang'

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -27,6 +27,11 @@ on:
         description: "P in ebuild: clash-meta-1.14.1"
         required: true
 
+      WORKDIR:
+        description: "source directory to preform scripts"
+        default: ''
+        required: false
+
 jobs:
   Generator:
     permissions: write-all # required by push tag
@@ -59,9 +64,10 @@ jobs:
         if: inputs.LANG == 'golang'
         env:
           P: ${{ inputs.P }}
+          WORKDIR: ${{ inputs.WORKDIR }}
         run: |
           git tag ${P} -m "${P}-deps.tar.xz ${P}-vendor.tar.xz"
-          cd input
+          cd "input/${WORKDIR}"
           GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
           tar --create --auto-compress --file /tmp/${P}-deps.tar.xz go-mod
           rm -rf go-mod
@@ -72,9 +78,10 @@ jobs:
         if: inputs.LANG == 'javascript'
         env:
           P: ${{ inputs.P }}
+          WORKDIR: ${{ inputs.WORKDIR }}
         run: |
           git tag ${P} -m "${P}-node_modules.tar.xz"
-          cd input
+          cd "input/${WORKDIR}"
           npm install --legacy-peer-deps --cache "${PWD}"/npm-cache
           tar --create --auto-compress --file /tmp/${P}-node_modules.tar.xz node_modules
           rm -rf node_modules
@@ -89,9 +96,10 @@ jobs:
         if: inputs.LANG == 'javascript(pnpm)'
         env:
           P: ${{ inputs.P }}
+          WORKDIR: ${{ inputs.WORKDIR }}
         run: |
           git tag ${P} -m "${P}-node_modules-pnpm.tar.xz"
-          cd input
+          cd "input/${WORKDIR}"
           pnpm install
           tar --create --auto-compress --file /tmp/${P}-node_modules-pnpm.tar.xz node_modules
           rm -rf node_modules


### PR DESCRIPTION
添加一个输入WORKDIR来支持在特定目录下进行操作
比如v2rayA这样的go代码不在项目根目录的，就会需要指定一个目录

默认的go是1.20，在使用1.21的项目里面就会报错：
https://github.com/liuyujielol/gentoo-go-deps/actions/runs/6721557611/job/18267540532#step:5:17
更新一下golang版本